### PR TITLE
Fixing Typos, Part 2

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -33,8 +33,8 @@ experimental design in industry.
 ::: a
 More information on my background can be found on the [about](about.qmd) section
 of the site and past projects from my time in academia are available on my 
-[github](https://github.com/ajnafa). respectively. I also write occasional 
+[github](https://github.com/ajnafa). I also write occasional 
 [blog posts](blog/index.qmd) on applied Bayesian statistics, causal inference, and data 
-science. If you are interested in my consulting services, please see the 
+science. If you are interested in enlisting my consulting services, please see the 
 [consulting](consulting.qmd) page.
 :::


### PR DESCRIPTION
This pull request includes minor text updates to the `index.qmd` file, improving clarity and grammar in the description of consulting services and other content.

* [`index.qmd`](diffhunk://#diff-142d492309aec76ce25caedd8d7eb0bdfe11ecdfa91f60eb015f56a406a41446L36-R38): Removed redundant wording ("respectively") and clarified phrasing related to consulting services ("enlisting my consulting services").